### PR TITLE
17 item endpoint

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,10 @@
+class API::V1::ItemsController < ApplicationController
+
+  def index
+    render json: Item.all
+  end
+
+  def show
+    render json: Item.find(params[:id])
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,4 +3,8 @@ class Item < ApplicationRecord
     :updated_at, :created_at, presence: true
 
   belongs_to :merchant
+
+  def unit_price
+    (unit_price_in_cents / 100.to_f).to_s
+  end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,7 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id,
+             :merchant_id,
+             :name,
+             :description,
+             :unit_price
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [:index, :show]
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,4 +13,12 @@ describe Item do
   describe 'relationships' do
     it { is_expected.to belong_to(:merchant) }
   end
+
+  describe '#unit_price' do
+    it "returns the unit price in dollars" do
+      item = create(:item, unit_price_in_cents: 12_34)
+
+      expect(item.unit_price).to eq "12.34"
+    end
+  end
 end

--- a/spec/requests/api/v1/endpoints/items_spec.rb
+++ b/spec/requests/api/v1/endpoints/items_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'Items API' do
+  it 'returns a list of items' do
+    item_1, item_2, item_3 = create_list(:item, 3)
+    name = item_1.name
+
+    get '/api/v1/items'
+    items = JSON.parse(response.body)
+    item = items.first
+
+    expect(response).to be_success
+    expect(items.count).to eq 3
+    expect(item['name']).to eq item_1.name
+  end
+
+  it 'returns a single item' do
+    create(:item, id: 5)
+
+    get '/api/v1/items/5'
+    item = JSON.parse(response.body)
+
+    expect(response).to be_success
+
+    expect(item).to be_a Hash
+    expect(item.keys.count).to eq 5
+    expect(item).to have_key 'id'
+    expect(item).to have_key 'merchant_id'
+    expect(item).to have_key 'name'
+    expect(item).to have_key 'description'
+    expect(item).to have_key 'unit_price'
+    expect(item['id']).to be_a Integer
+    expect(item['merchant_id']).to be_a Integer
+    expect(item['name']).to be_a String
+    expect(item['description']).to be_a String
+    expect(item['unit_price']).to be_a String
+  end
+end


### PR DESCRIPTION
@kheppenstall 

I followed the same format as your merchant endpoints.  I just had to add one method to return the `unit_price` since we're storing the price in cents, but the API needs to return the price in dollars.  Oddly, the spec harness wanted it formatted as a string...

Ready for review.