### PR TITLE
23 transaction relationships

### DIFF
--- a/app/controllers/api/v1/transactions/invoice_controller.rb
+++ b/app/controllers/api/v1/transactions/invoice_controller.rb
@@ -1,0 +1,6 @@
+class API::V1::Transactions::InvoiceController < ApplicationController
+  def show
+    transaction = Transaction.find(params[:transaction_id])
+    render json: transaction.invoice
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,11 @@ Rails.application.routes.draw do
         get "/find_all", to: "find#index"
         get "/random", to: "random#show"
       end
-      resources :transactions, only: [:show, :index]
+      resources :transactions, only: [:show, :index] do
+        scope module: :transactions do
+          get "/invoice", to: "invoice#show"
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/v1/relationships/transaction_spec.rb
+++ b/spec/requests/api/v1/relationships/transaction_spec.rb
@@ -7,13 +7,12 @@ describe 'Transactions API relationship' do
     invoice = transaction.invoice
 
     get "/api/v1/transactions/#{transaction.id}/invoice"
-    invoice = JSON.parse(response.body)
+    response_invoice = JSON.parse(response.body)
 
     expect(response).to be_success
-    expect(invoice).to be_a Hash
-    expect(invoice_id).to eq invoice['id']
-    expect(invoice.merchant_id).to eq invoice['merchant_id']
-    expect(invoice.customer).to eq invoice['customer_id']
-    expect(invoice.keys.count).to eq 3
+    expect(response_invoice).to be_a Hash
+    expect(response_invoice['id']).to eq invoice.id
+    expect(response_invoice['merchant_id']).to eq invoice.merchant_id
+    expect(response_invoice['customer_id']).to eq invoice.customer_id
   end
 end

--- a/spec/requests/api/v1/relationships/transaction_spec.rb
+++ b/spec/requests/api/v1/relationships/transaction_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Transactions API relationship' do
+
+  it 'invoice' do
+    transaction = create(:transaction)
+    invoice = transaction.invoice
+
+    get "/api/v1/transactions/#{transaction.id}/invoice"
+    invoice = JSON.parse(response.body)
+
+    expect(response).to be_success
+    expect(invoice).to be_a Hash
+    expect(invoice_id).to eq invoice['id']
+    expect(invoice.merchant_id).to eq invoice['merchant_id']
+    expect(invoice.customer).to eq invoice['customer_id']
+    expect(invoice.keys.count).to eq 3
+  end
+end


### PR DESCRIPTION
Invoice relationship in transaction API

Closes #23 

@ski-climb Ready for review. Checkout `routes.rb`. Had to do something a little different than we planned since the route was `/api/v1/transactions/:id/invoice` not `/api/v1/transactions/:id/invoice/:id`.

@sallymacnicholas This is our first relationships API.

Does not make the spec harness pass since the serializer for invoices is not set yet.