### PR TITLE
Item best day responds to test

### DIFF
--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -23,6 +23,10 @@ describe Item do
     end
   end
 
+  describe '.best_day' do
+    it { is_expected.to respond_to(:best_day) }
+  end
+
   describe '#unit_price' do
     it "returns the unit price in dollars" do
       item = create(:item, unit_price_in_cents: 12_34)


### PR DESCRIPTION
Add a `responds_to` test for `item#best_day`

@ski-climb Ready for review. The only one I found missing a responds to method was `#best_day` for an item instance.

Closes #56