### PR TITLE
64 refactor queries

### DIFF
--- a/app/controllers/api/v1/merchants/revenue_by_second_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_by_second_controller.rb
@@ -1,6 +1,6 @@
 class API::V1::Merchants::RevenueBySecondController < ApplicationController
   def show
-    total_revenue = Invoice.revenue_by_day(params[:date])
+    total_revenue = Merchant.revenue_by_day(params[:date])
     render json: total_revenue, serializer: MerchantTotalRevenueSerializer
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,11 +16,5 @@ class Invoice < ApplicationRecord
       all
     end
   end
-
-  def self.revenue_by_day(day)
-      joins(:transactions, :invoice_items)
-      .merge(Transaction.successful)
-      .merge(self.on_date(day))
-      .sum('unit_price_in_cents * quantity')
-  end
 end
+

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -9,8 +9,8 @@ class Merchant < ApplicationRecord
 
   def revenue(date)
     invoices.on_date(date)
-      .joins(:transactions, :invoice_items)
-      .merge(Transaction.successful)
+      .joins(:invoice_items)
+      .merge(InvoiceItem.successful)
       .sum('unit_price_in_cents * quantity')
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -13,4 +13,11 @@ class Merchant < ApplicationRecord
       .merge(InvoiceItem.successful)
       .sum('unit_price_in_cents * quantity')
   end
+
+  def self.revenue_by_day(date)
+    joins(:invoice_items)
+    .merge(Invoice.on_date(date))
+    .merge(InvoiceItem.successful)
+    .sum('unit_price_in_cents * quantity')
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -23,10 +23,4 @@ describe Invoice do
       expect(invoice.status).to eq "shipped"
     end
   end
-
-  describe ".revenue_by_day" do
-    it "responds to revenue_by_day"do
-      expect(Invoice).to respond_to(:revenue_by_day)
-    end
-  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -13,4 +13,10 @@ describe Merchant do
     it { is_expected.to have_many(:transactions) }
     it { is_expected.to have_many(:invoice_items) }
   end
+
+  describe ".revenue_by_day" do
+    it "responds to revenue_by_day"do
+      expect(Merchant).to respond_to(:revenue_by_day)
+    end
+  end
 end

--- a/spec/requests/api/v1/business-intelligence/merchant_revenue_spec.rb
+++ b/spec/requests/api/v1/business-intelligence/merchant_revenue_spec.rb
@@ -73,7 +73,7 @@ describe 'Merchant API revenue' do
       get "/api/v1/merchants/revenue?date=#{sliver_of_time}"
 
       expect(response).to be_success
-      expect(Invoice.revenue_by_day(sliver_of_time)).to eq expected_revenue
+      expect(Merchant.revenue_by_day(sliver_of_time)).to eq expected_revenue
     end
   end
 end


### PR DESCRIPTION
Refactor `merchant#revenue` to include the `InvoiceItem.successful` scope
Move `.revenue_by_day(date)` from `invoice.rb` to `merchant.rb`

Closes #64

@ski-climb I implemented a suggestion from @sallymacnicholas to move `.revenue_by_day` into Merchant (it was previously in Invoice). Check out the Slack channel for the conversatoin.