### PR TITLE
49 merchants by revenue

### DIFF
--- a/app/controllers/api/v1/merchants/most_revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/most_revenue_controller.rb
@@ -1,0 +1,6 @@
+class API::V1::Merchants::MostRevenueController < ApplicationController
+
+  def index
+    render json: Merchant.most_revenue(params[:quantity])
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -13,4 +13,12 @@ class Merchant < ApplicationRecord
       .merge(Transaction.successful)
       .sum('unit_price_in_cents * quantity')
   end
+
+  def self.most_revenue(number_of_merchants)
+    joins(:invoice_items)
+      .merge(InvoiceItem.successful)
+      .group("merchants.id")
+      .order("sum(quantity * unit_price_in_cents) DESC")
+      .take(number_of_merchants.to_i)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
         get "/find_all", to: "find#index"
         get "/random", to: "random#show"
         get "/revenue", to: "revenue_by_second#show"
+        get "/most_revenue", to: "most_revenue#index"
       end
       resources :merchants, only: [:index, :show] do
         scope module: :merchants do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,10 +7,17 @@ describe Merchant do
     it { is_expected.to validate_presence_of(:created_at) }
   end
 
-  describe "relationships" do
+  describe 'relationships' do
     it { is_expected.to have_many(:invoices) }
     it { is_expected.to have_many(:items) }
     it { is_expected.to have_many(:transactions) }
     it { is_expected.to have_many(:invoice_items) }
   end
+
+  describe '.most_revenue' do
+    it 'responds to most_revenue' do
+      expect(Merchant).to respond_to(:most_revenue)
+    end
+  end
+
 end

--- a/spec/requests/api/v1/business-intelligence/merchants_most_revenue_spec.rb
+++ b/spec/requests/api/v1/business-intelligence/merchants_most_revenue_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe 'Merchant API most revenue endpoint' do
+  let!(:merchant_1) { create(:merchant) }
+  let!(:merchant_2) { create(:merchant) }
+  let!(:invoice_1) { create(:invoice, merchant: merchant_1) }
+  let!(:invoice_2) { create(:invoice, merchant: merchant_2) }
+  let!(:transaction_1) { create(:transaction, invoice: invoice_1, result: "success") }
+  let!(:transaction_2) { create(:transaction, invoice: invoice_2, result: "success") }
+  let!(:invoice_item_1) { create(:invoice_item, invoice: invoice_1, quantity: 1, unit_price_in_cents: 1_000_00) }
+  let!(:invoice_items) { create_list(:invoice_item, 50, invoice: invoice_2, quantity: 10, unit_price_in_cents: 1_00) }
+
+  context 'smaller quantity but higher revenue' do
+    it 'returns the merchants ranked by total revenue' do
+      get '/api/v1/merchants/most_revenue?quantity=2'
+      merchants = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(merchants).to be_an Array
+      expect(merchants.count).to be 2
+      expect(merchants.first['id']).to eq merchant_1.id
+      expect(merchants.first['name']).to eq merchant_1.name
+      expect(merchants.last['id']).to eq merchant_2.id
+      expect(merchants.last['name']).to eq merchant_2.name
+    end
+  end
+
+  context 'successful and unsuccessful transations' do
+    let!(:invoice_3) { create(:invoice, merchant: merchant_1) }
+    let!(:transaction_3) { create(:transaction, invoice: invoice_3, result: "failed") }
+    let!(:invoice_item_2) { create(:invoice_item, invoice: invoice_2, quantity: 10, unit_price_in_cents: 5_000_00) }
+    let!(:invoice_item_3) { create(:invoice_item, invoice: invoice_3, quantity: 1, unit_price_in_cents: 2_000_00) }
+
+    it 'returns the merchants ranked by total revenue' do
+
+      get '/api/v1/merchants/most_revenue?quantity=2'
+      merchants = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(merchants).to be_an Array
+      expect(merchants.count).to be 2
+      expect(merchants.first['id']).to eq merchant_2.id
+      expect(merchants.first['name']).to eq merchant_2.name
+      expect(merchants.last['id']).to eq merchant_1.id
+      expect(merchants.last['name']).to eq merchant_1.name
+    end
+  end
+end


### PR DESCRIPTION
closes #49 

This lists merchants by total revenue (and you can select the number of merchants a-la:
`GET /api/v1/items/most_revenue?quantity=9`

@kheppenstall ready for review!
@sallymacnicholas FYI