### PR TITLE
Refactor unit price

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -11,8 +11,4 @@ class InvoiceItem < ApplicationRecord
   has_many :transactions, through: :invoice
 
   scope :successful, -> { joins(:transactions).merge(Transaction.successful) }
-
-  def unit_price
-    (unit_price_in_cents / 100.to_f).to_s
-  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,10 +6,6 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
 
-  def unit_price
-    (unit_price_in_cents / 100.to_f).to_s
-  end
-
   def self.most_items(quantity)
     joins(:invoice_items)
       .merge(InvoiceItem.successful)

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -4,4 +4,8 @@ class InvoiceItemSerializer < ActiveModel::Serializer
              :item_id,
              :quantity,
              :unit_price
+
+  def unit_price
+    (object.unit_price_in_cents / 100.to_f).to_s
+  end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -4,4 +4,8 @@ class ItemSerializer < ActiveModel::Serializer
              :name,
              :description,
              :unit_price
+
+  def unit_price
+    (object.unit_price_in_cents / 100.to_f).to_s
+  end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -73,12 +73,4 @@ describe InvoiceItem do
       end
     end
   end
-
-  describe '#unit_price' do
-    it "returns the unit price in dollars" do
-      invoice_item = create(:invoice_item, unit_price_in_cents: 12_34)
-
-      expect(invoice_item.unit_price).to eq "12.34"
-    end
-  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -33,12 +33,4 @@ describe Item do
   describe '.best_day' do
     it { is_expected.to respond_to(:best_day) }
   end
-
-  describe '#unit_price' do
-    it "returns the unit price in dollars" do
-      item = create(:item, unit_price_in_cents: 12_34)
-
-      expect(item.unit_price).to eq "12.34"
-    end
-  end
 end

--- a/spec/requests/api/v1/finders/invoice_items_spec.rb
+++ b/spec/requests/api/v1/finders/invoice_items_spec.rb
@@ -6,7 +6,7 @@ describe 'invoice_items API' do
 
   context 'find by' do
     let!(:invoice_item_1) { create(:invoice_item) }
-    let!(:invoice_item_2) { create(:invoice_item) }
+    let!(:invoice_item_2) { create(:invoice_item, quantity: 1_000_000) }
     let!(:invoice_item_3) { create(:invoice_item) }
 
     it 'id' do
@@ -43,25 +43,25 @@ describe 'invoice_items API' do
     end
 
     it 'unit_price' do
-      unit_price = invoice_item_2.unit_price
+      unit_price = invoice_item_2.unit_price_in_cents / 100.to_f
 
       get '/api/v1/invoice_items/find', params: {unit_price: unit_price}
       invoice_item = JSON.parse(response.body)
 
       expect(response).to be_success
       expect(invoice_item['id']).to eq invoice_item_2.id
-      expect(invoice_item['unit_price']).to eq invoice_item_2.unit_price
+      expect(invoice_item['unit_price']).to eq (invoice_item_2.unit_price_in_cents / 100.to_f).to_s
     end
 
     it 'quantity' do
-      quantity = invoice_item_2.quantity
+      quantity = 1_000_000
 
       get '/api/v1/invoice_items/find', params: {quantity: quantity}
       invoice_item = JSON.parse(response.body)
 
       expect(response).to be_success
       expect(invoice_item['id']).to eq invoice_item_2.id
-      expect(invoice_item['quantity']).to eq invoice_item_2.quantity
+      expect(invoice_item['quantity']).to eq 1_000_000
     end
 
     it 'created_at' do
@@ -105,7 +105,7 @@ describe 'invoice_items API' do
     let!(:item) { create(:item) }
     let!(:item_4) { create(:item, id: 4) }
 
-    let!(:invoice_item_1) { create(:invoice_item) }
+    let!(:invoice_item_1) { create(:invoice_item, quantity: 99) }
     let!(:invoice_item_2) { create(:invoice_item, quantity: 3, unit_price_in_cents: 12_34, invoice_id: 5) }
     let!(:invoice_item_3) { create(:invoice_item, quantity: 3, item_id: 4) }
     let!(:invoice_item_4) { create(:invoice_item, quantity: 2, invoice_id: 5, item_id: 4, unit_price_in_cents: 12_34, created_at: date, updated_at: date) }

--- a/spec/requests/api/v1/finders/items_spec.rb
+++ b/spec/requests/api/v1/finders/items_spec.rb
@@ -43,14 +43,14 @@ describe 'Items API' do
     end
 
     it 'unit_price' do
-      unit_price = item_2.unit_price
+      unit_price = item_2.unit_price_in_cents / 100.to_f
 
       get '/api/v1/items/find', params: {unit_price: unit_price}
       item = JSON.parse(response.body)
 
       expect(response).to be_success
       expect(item['id']).to eq item_2.id
-      expect(item['unit_price']).to eq item_2.unit_price
+      expect(item['unit_price']).to eq (item_2.unit_price_in_cents / 100.to_f).to_s
     end
 
     it 'merchant_id' do


### PR DESCRIPTION
closes #51 

I moved the `unit_price` methods out of the models, and the API tests cover their use, so I was Ok removing the model tests.

Also, I think I found the fix for the blinking tests for `quantity` and made a change that should prevent the blink (fingers crossed).